### PR TITLE
process_tracker_python-30 Extract Lookups should return Extract objects

### DIFF
--- a/process_tracker/models/actor.py
+++ b/process_tracker/models/actor.py
@@ -11,3 +11,7 @@ class Actor(Base):
 
     actor_id = Column(Integer, Sequence('actor_lkup_actor_id_seq'), primary_key=True)
     actor_name = Column(String(250), nullable=False, unique=True)
+
+    def __repr__(self):
+        return "<Actor id=%s, name=%s>" % (self.actor_id
+                                          , self.actor_name)

--- a/process_tracker/models/extract.py
+++ b/process_tracker/models/extract.py
@@ -2,6 +2,7 @@
 # Models for Extract (Data) entities
 
 from datetime import datetime
+from os.path import join
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, Sequence, String
 from sqlalchemy.orm import relationship
@@ -18,6 +19,11 @@ class ExtractStatus(Base):
 
     extracts = relationship("ExtractProcess")
 
+    def __repr__(self):
+
+        return "<Extract Status id=%s, name=%s>" % (self.extract_status_id
+                                                    , self.extract_status_name)
+
 
 class Extract(Base):
 
@@ -32,6 +38,17 @@ class Extract(Base):
     extract_process = relationship("ExtractProcess", back_populates='process_extracts')
     locations = relationship("Location", foreign_keys=[extract_location_id])
 
+    def __repr__(self):
+
+        return "<Extract id=%s, filename=%s, location=%s, status=%s>" % (self.extract_id
+                                                                         , self.extract_filename
+                                                                         , self.extract_location_id
+                                                                         , self.extract_status_id)
+
+    def full_filepath(self):
+
+        return join(self.locations.location_path, self.extract_filename)
+
 
 class ExtractProcess(Base):
 
@@ -45,6 +62,12 @@ class ExtractProcess(Base):
     process_extracts = relationship('Extract', foreign_keys=[extract_tracking_id])
     extract_processes = relationship('ProcessTracking', foreign_keys=[process_tracking_id])
 
+    def __repr__(self):
+
+        return "<ExtractProcess extract=%s, process_run=%s, extract_status=%s>" % (self.extract_tracking_id
+                                                                                   , self.process_tracking_id
+                                                                                   , self.extract_process_status_id)
+
 
 class LocationType(Base):
 
@@ -54,7 +77,12 @@ class LocationType(Base):
     location_type_name = Column(String(25), unique=True, nullable=False)
 
     locations = relationship('Location', back_populates='location_types')
-    
+
+    def __repr__(self):
+
+        return "<LocationType id=%s, name=%s>" % (self.location_type_id
+                                                  , self.location_type_name)
+
 
 class Location(Base):
 
@@ -68,3 +96,9 @@ class Location(Base):
     extracts = relationship("Extract")
 
     location_types = relationship('LocationType', foreign_keys=[location_type])
+
+    def __repr__(self):
+
+        return "<Location id=%s, name=%s, type=%s>" % (self.location_id
+                                                       , self.location_name
+                                                       , self.location_path)

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -431,8 +431,8 @@ class TestProcessTracker(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             # Running registration a second time to mimic job being run twice
             self.process_tracker.register_new_process_run()
-
-        return self.assertTrue('Process Testing Process Tracking Initialization '
+        print(context.exception)
+        return self.assertTrue('The process Testing Process Tracking Initialization '
                                'is currently running.' in str(context.exception))
 
     def test_register_new_process_run_with_previous_run(self):

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -129,8 +129,9 @@ class TestProcessTracker(unittest.TestCase):
         expected_result = ['/home/test/extract_dir/test_extract_filename2.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_filename('test_extract_filename2.csv')
+        given_result = [record.full_filepath() for record in given_result]
 
-        self.assertEqual(expected_result, given_result)
+        self.assertCountEqual(expected_result, given_result)
 
     def test_find_ready_extracts_by_filename_partial(self):
         """
@@ -161,8 +162,9 @@ class TestProcessTracker(unittest.TestCase):
                            , '/home/test/extract_dir/test_extract_filename3-2.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_filename('test_extract_filename')
+        given_result = [record.full_filepath() for record in given_result]
 
-        self.assertEqual(expected_result, given_result)
+        self.assertCountEqual(expected_result, given_result)
 
     def test_find_ready_extracts_by_filename_partial_not_descending(self):
         """
@@ -193,6 +195,7 @@ class TestProcessTracker(unittest.TestCase):
                            , '/home/test/extract_dir/test_extract_filename3-1.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_filename('test_extract_filename')
+        given_result = [record.full_filepath() for record in given_result]
 
         self.assertNotEqual(expected_result, given_result)
 
@@ -225,8 +228,9 @@ class TestProcessTracker(unittest.TestCase):
                            , '/home/test/extract_dir/test_extract_filename4-2.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_location('Test Location')
+        given_result = [record.full_filepath() for record in given_result]
 
-        self.assertEqual(expected_result, given_result)
+        self.assertCountEqual(expected_result, given_result)
 
     def test_find_ready_extracts_by_location_not_descending(self):
         """
@@ -257,6 +261,7 @@ class TestProcessTracker(unittest.TestCase):
                            , '/home/test/extract_dir/test_extract_filename4-1.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_location('Test Location')
+        given_result = [record.full_filepath() for record in given_result]
 
         self.assertNotEqual(expected_result, given_result)
 
@@ -288,8 +293,9 @@ class TestProcessTracker(unittest.TestCase):
                            , '/home/test/extract_dir/test_extract_filename5-2.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_process('Testing Process Tracking Initialization')
+        given_result = [record.full_filepath() for record in given_result]
 
-        self.assertEqual(sorted(expected_result), sorted(given_result))
+        self.assertCountEqual(expected_result, given_result)
 
     def test_find_ready_extracts_by_process_not_descending(self):
         """
@@ -323,6 +329,7 @@ class TestProcessTracker(unittest.TestCase):
             , '/home/test/extract_dir/test_extract_filename5-1.csv']
 
         given_result = self.process_tracker.find_ready_extracts_by_process('Testing Process Tracking Initialization')
+        given_result = [record.full_filepath() for record in given_result]
 
         self.assertNotEqual(expected_result, given_result)
 


### PR DESCRIPTION
All the extract file finders now return extract objects so they can be
modified as they are used.  A helper method was also added that provides
the full filename of a given extract (called full_filepath).

Also realized that I missed adding string representations of a bunch of
the data models.

Closes #30