### PR TITLE
process_tracker_python-21 Add or Delete Process Dependencies From CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Data integration process management made easy!
 [![PyPI version](https://badge.fury.io/py/processtracker.svg)](https://badge.fury.io/py/processtracker)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Documentation Status](https://readthedocs.org/projects/process-tracker/badge/?version=latest)](https://process-tracker.readthedocs.io/en/latest/?badge=latest)
 
 This is the Python implementation of the ProcessTracker framework.  ProcessTracker builds a standard framework that is
 tool agnostic.  If you are working with data integration/cleansing processes within Python (i.e. using PySpark, Pandas, etc.)

--- a/process_tracker/cli.py
+++ b/process_tracker/cli.py
@@ -44,31 +44,51 @@ def main():
 @main.command()
 @click.option("-t", "--topic", help="The topic being created")
 @click.option("-n", "--name", help="The name for the topic.")
-def create(topic, name):
+@click.option(
+    "-p", "--parent", help="The parent process' name, if creating a process dependency"
+)
+@click.option(
+    "-c", "--child", help="The child process' name, if creating a process dependency"
+)
+def create(topic, name, parent=None, child=None):
     """
     Create an item that is within the valid topics list.
     :param topic: The name of the topic.
     :type topic: string
     :param name: The name of the topic item to be added.
     :type name: string
+    :param parent: The parent process' name, if creating a process dependency
+    :type parent: string
+    :param child: The child process' name, if creating a process dependency
+    :type child: string
     """
     click.echo("Attempting to create %s with name %s" % (topic, name))
-    data_store.topic_creator(topic=topic, name=name)
+    data_store.topic_creator(topic=topic, name=name, parent=parent, child=child)
 
 
 @main.command()
 @click.option("-t", "--topic", help="The topic being created")
 @click.option("-n", "--name", help="The name for the topic.")
-def delete(topic, name):
+@click.option(
+    "-p", "--parent", help="The parent process' name, if deleting a process dependency"
+)
+@click.option(
+    "-c", "--child", help="The child process' name, if deleting a process dependency"
+)
+def delete(topic, name, parent=None, child=None):
     """
     Delete an item that is within the valid topics list and not a pre-loaded item.
     :param topic: The name of the topic.
     :type topic: string
     :param name: The name of the topic item to be deleted.
     :type name: string
+    :param parent: The parent process' name, if deleting a process dependency
+    :type parent: string
+    :param child: The child process' name, if deleting a process dependency
+    :type child: string
     """
     click.echo("Attempting to delete %s with name %s" % (topic, name))
-    data_store.topic_deleter(topic=topic, name=name)
+    data_store.topic_deleter(topic=topic, name=name, parent=parent, child=child)
 
 
 @main.command()


### PR DESCRIPTION
:sparkles: Ability to create and delete Process Dependencies from CLI

Process Dependencies can now be managed via the CLI tool.

Closes:#21