### PR TITLE
process_tracker_python-33 CLI Cascade Delete?

### DIFF
--- a/process_tracker/models/actor.py
+++ b/process_tracker/models/actor.py
@@ -14,6 +14,7 @@ class Actor(Base):
         Integer,
         Sequence("actor_lkup_actor_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     actor_name = Column(String(250), nullable=False, unique=True)
 

--- a/process_tracker/models/capacity.py
+++ b/process_tracker/models/capacity.py
@@ -17,6 +17,7 @@ class Cluster(Base):
         Integer,
         Sequence("cluster_tracking_cluster_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     cluster_name = Column(String(250), unique=True, nullable=False)
     cluster_max_memory = Column(Integer, nullable=True)
@@ -26,7 +27,7 @@ class Cluster(Base):
     cluster_current_memory_usage = Column(Integer)
     cluster_current_process_usage = Column(Integer)
 
-    process_clusters = relationship("ClusterProcess")
+    process_clusters = relationship("ClusterProcess", passive_deletes="all")
 
     def __repr__(self):
 
@@ -42,11 +43,21 @@ class ClusterProcess(Base):
         Integer,
         ForeignKey("process_tracker.cluster_tracking.cluster_id"),
         primary_key=True,
+        nullable=False,
     )
-    process_id = Column(Integer, ForeignKey("process_tracker.process.process_id"))
+    process_id = Column(
+        Integer,
+        ForeignKey("process_tracker.process.process_id"),
+        primary_key=True,
+        nullable=False,
+    )
 
-    processes = relationship("Process", back_populates="cluster_processes")
-    clusters = relationship("Cluster", back_populates="process_clusters")
+    processes = relationship(
+        "Process", back_populates="cluster_processes", passive_deletes="all"
+    )
+    clusters = relationship(
+        "Cluster", back_populates="process_clusters", passive_deletes="all"
+    )
 
     def __repr__(self):
 

--- a/process_tracker/models/extract.py
+++ b/process_tracker/models/extract.py
@@ -19,6 +19,7 @@ class ExtractStatus(Base):
         Integer,
         Sequence("extract_status_lkup_extract_status_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     extract_status_name = Column(String(75), nullable=False, unique=True)
 
@@ -41,13 +42,16 @@ class Extract(Base):
         Integer,
         Sequence("extract_tracking_extract_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     extract_filename = Column(String(750), nullable=False, unique=True)
     extract_location_id = Column(
-        Integer, ForeignKey("process_tracker.location_lkup.location_id")
+        Integer, ForeignKey("process_tracker.location_lkup.location_id"), nullable=False
     )
     extract_status_id = Column(
-        Integer, ForeignKey("process_tracker.extract_status_lkup.extract_status_id")
+        Integer,
+        ForeignKey("process_tracker.extract_status_lkup.extract_status_id"),
+        nullable=False,
     )
     extract_registration_date_time = Column(
         DateTime, nullable=False, default=datetime.now()
@@ -59,9 +63,15 @@ class Extract(Base):
     extract_load_high_date_time = Column(DateTime, nullable=True)
     extract_load_record_count = Column(Integer, nullable=True)
 
-    extract_process = relationship("ExtractProcess", back_populates="process_extracts")
-    extract_status = relationship("ExtractStatus", foreign_keys=[extract_status_id])
-    locations = relationship("Location", foreign_keys=[extract_location_id])
+    extract_process = relationship(
+        "ExtractProcess", back_populates="process_extracts", passive_deletes="all"
+    )
+    extract_status = relationship(
+        "ExtractStatus", foreign_keys=[extract_status_id], passive_deletes="all"
+    )
+    locations = relationship(
+        "Location", foreign_keys=[extract_location_id], passive_deletes="all"
+    )
 
     def __repr__(self):
 
@@ -85,15 +95,21 @@ class ExtractDependency(Base):
         Integer,
         ForeignKey("process_tracker.extract_tracking.extract_id"),
         primary_key=True,
+        nullable=False,
     )
     child_extract_id = Column(
         Integer,
         ForeignKey("process_tracker.extract_tracking.extract_id"),
         primary_key=True,
+        nullable=False,
     )
 
-    child_extract = relationship("Extract", foreign_keys=[child_extract_id])
-    parent_extract = relationship("Extract", foreign_keys=[parent_extract_id])
+    child_extract = relationship(
+        "Extract", foreign_keys=[child_extract_id], passive_deletes="all"
+    )
+    parent_extract = relationship(
+        "Extract", foreign_keys=[parent_extract_id], passive_deletes="all"
+    )
 
     def __repr__(self):
 
@@ -112,22 +128,28 @@ class ExtractProcess(Base):
         Integer,
         ForeignKey("process_tracker.extract_tracking.extract_id"),
         primary_key=True,
+        nullable=False,
     )
     process_tracking_id = Column(
         Integer,
         ForeignKey("process_tracker.process_tracking.process_tracking_id"),
         primary_key=True,
+        nullable=False,
     )
     extract_process_status_id = Column(
-        Integer, ForeignKey("process_tracker.extract_status_lkup.extract_status_id")
+        Integer,
+        ForeignKey("process_tracker.extract_status_lkup.extract_status_id"),
+        nullable=False,
     )
     extract_process_event_date_time = Column(
         DateTime, nullable=False, default=datetime.now()
     )
 
-    process_extracts = relationship("Extract", foreign_keys=[extract_tracking_id])
+    process_extracts = relationship(
+        "Extract", foreign_keys=[extract_tracking_id], passive_deletes="all"
+    )
     extract_processes = relationship(
-        "ProcessTracking", foreign_keys=[process_tracking_id]
+        "ProcessTracking", foreign_keys=[process_tracking_id], passive_deletes="all"
     )
 
     def __repr__(self):
@@ -148,10 +170,13 @@ class LocationType(Base):
         Integer,
         Sequence("location_type_lkup_location_type_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     location_type_name = Column(String(25), unique=True, nullable=False)
 
-    locations = relationship("Location", back_populates="location_types")
+    locations = relationship(
+        "Location", back_populates="location_types", passive_deletes="all"
+    )
 
     def __repr__(self):
 
@@ -170,16 +195,21 @@ class Location(Base):
         Integer,
         Sequence("location_lkup_location_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     location_name = Column(String(750), nullable=False, unique=True)
     location_path = Column(String(750), nullable=False, unique=True)
     location_type = Column(
-        Integer, ForeignKey("process_tracker.location_type_lkup.location_type_id")
+        Integer,
+        ForeignKey("process_tracker.location_type_lkup.location_type_id"),
+        nullable=False,
     )
 
     extracts = relationship("Extract")
 
-    location_types = relationship("LocationType", foreign_keys=[location_type])
+    location_types = relationship(
+        "LocationType", foreign_keys=[location_type], passive_deletes="all"
+    )
 
     def __repr__(self):
 

--- a/process_tracker/models/process.py
+++ b/process_tracker/models/process.py
@@ -17,10 +17,11 @@ class ErrorType(Base):
         Integer,
         Sequence("error_type_lkup_error_type_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     error_type_name = Column(String(250), unique=True, nullable=False)
 
-    process_errors = relationship("ErrorTracking")
+    process_errors = relationship("ErrorTracking", passive_deletes="all")
 
     def __repr__(self):
 
@@ -36,17 +37,22 @@ class ErrorTracking(Base):
         Integer,
         Sequence("error_tracking_error_tracking_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     error_type_id = Column(
-        Integer, ForeignKey("process_tracker.error_type_lkup.error_type_id")
+        Integer,
+        ForeignKey("process_tracker.error_type_lkup.error_type_id"),
+        nullable=False,
     )
     error_description = Column(String(750))
     error_occurrence_date_time = Column(DateTime, nullable=False)
     process_tracking_id = Column(
-        Integer, ForeignKey("process_tracker.process_tracking.process_tracking_id")
+        Integer,
+        ForeignKey("process_tracker.process_tracking.process_tracking_id"),
+        nullable=False,
     )
 
-    error_tracking = relationship("ProcessTracking")
+    error_tracking = relationship("ProcessTracking", passive_deletes="all")
 
     def __repr__(self):
 
@@ -71,6 +77,7 @@ class ProcessStatus(Base):
         Integer,
         Sequence("process_status_lkup_process_status_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     process_status_name = Column(String(75), nullable=False, unique=True)
 
@@ -91,10 +98,11 @@ class ProcessType(Base):
         Integer,
         Sequence("process_type_lkup_process_type_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     process_type_name = Column(String(250), nullable=False)
 
-    processes = relationship("Process")
+    processes = relationship("Process", passive_deletes="all")
 
     def __repr__(self):
 
@@ -113,23 +121,30 @@ class Process(Base):
         Integer,
         Sequence("process_process_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     process_name = Column(String(250), nullable=False, unique=True)
     total_record_count = Column(Integer, nullable=False, default=0)
     process_type_id = Column(
-        Integer, ForeignKey("process_tracker.process_type_lkup.process_type_id")
+        Integer,
+        ForeignKey("process_tracker.process_type_lkup.process_type_id"),
+        nullable=False,
     )
-    process_tool_id = Column(Integer, ForeignKey("process_tracker.tool_lkup.tool_id"))
+    process_tool_id = Column(
+        Integer, ForeignKey("process_tracker.tool_lkup.tool_id"), nullable=False
+    )
     last_failed_run_date_time = Column(
         DateTime(timezone=True), nullable=False, default=default_date
     )
 
-    cluster_processes = relationship("ClusterProcess")
-    process_tracking = relationship("ProcessTracking")
-    process_type = relationship("ProcessType", back_populates="processes")
-    sources = relationship("ProcessSource")
-    targets = relationship("ProcessTarget")
-    tool = relationship("Tool")
+    cluster_processes = relationship("ClusterProcess", passive_deletes="all")
+    process_tracking = relationship("ProcessTracking", passive_deletes="all")
+    process_type = relationship(
+        "ProcessType", back_populates="processes", passive_deletes="all"
+    )
+    sources = relationship("ProcessSource", passive_deletes="all")
+    targets = relationship("ProcessTarget", passive_deletes="all")
+    tool = relationship("Tool", passive_deletes="all")
 
     def __repr__(self):
 
@@ -146,14 +161,20 @@ class ProcessSource(Base):
     __table_args__ = {"schema": "process_tracker"}
 
     source_id = Column(
-        Integer, ForeignKey("process_tracker.source_lkup.source_id"), primary_key=True
+        Integer,
+        ForeignKey("process_tracker.source_lkup.source_id"),
+        primary_key=True,
+        nullable=False,
     )
     process_id = Column(
-        Integer, ForeignKey("process_tracker.process.process_id"), primary_key=True
+        Integer,
+        ForeignKey("process_tracker.process.process_id"),
+        primary_key=True,
+        nullable=False,
     )
 
-    sources = relationship("Source")
-    processes = relationship("Process")
+    sources = relationship("Source", passive_deletes="all")
+    processes = relationship("Process", passive_deletes="all")
 
     def __repr__(self):
 
@@ -168,14 +189,20 @@ class ProcessTarget(Base):
     __table_args__ = {"schema": "process_tracker"}
 
     target_source_id = Column(
-        Integer, ForeignKey("process_tracker.source_lkup.source_id"), primary_key=True
+        Integer,
+        ForeignKey("process_tracker.source_lkup.source_id"),
+        primary_key=True,
+        nullable=False,
     )
     process_id = Column(
-        Integer, ForeignKey("process_tracker.process.process_id"), primary_key=True
+        Integer,
+        ForeignKey("process_tracker.process.process_id"),
+        primary_key=True,
+        nullable=False,
     )
 
-    targets = relationship("Source")
-    processes = relationship("Process")
+    targets = relationship("Source", passive_deletes="all")
+    processes = relationship("Process", passive_deletes="all")
 
     def __repr__(self):
         return "<ProcessSource (process=%s, target_source=%s)>" % (
@@ -190,14 +217,24 @@ class ProcessDependency(Base):
     __table_args__ = {"schema": "process_tracker"}
 
     parent_process_id = Column(
-        Integer, ForeignKey("process_tracker.process.process_id"), primary_key=True
+        Integer,
+        ForeignKey("process_tracker.process.process_id"),
+        primary_key=True,
+        nullable=False,
     )
     child_process_id = Column(
-        Integer, ForeignKey("process_tracker.process.process_id"), primary_key=True
+        Integer,
+        ForeignKey("process_tracker.process.process_id"),
+        primary_key=True,
+        nullable=False,
     )
 
-    child_process = relationship("Process", foreign_keys=[child_process_id])
-    parent_process = relationship("Process", foreign_keys=[parent_process_id])
+    child_process = relationship(
+        "Process", foreign_keys=[child_process_id], passive_deletes="all"
+    )
+    parent_process = relationship(
+        "Process", foreign_keys=[parent_process_id], passive_deletes="all"
+    )
 
     def __repr__(self):
 
@@ -216,10 +253,13 @@ class ProcessTracking(Base):
         Integer,
         Sequence("process_tracking_process_tracking_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     process_id = Column(Integer, ForeignKey("process_tracker.process.process_id"))
     process_status_id = Column(
-        Integer, ForeignKey("process_tracker.process_status_lkup.process_status_id")
+        Integer,
+        ForeignKey("process_tracker.process_status_lkup.process_status_id"),
+        nullable=False,
     )
     process_run_id = Column(Integer, nullable=False)
     process_run_low_date_time = Column(DateTime, nullable=True)
@@ -228,13 +268,19 @@ class ProcessTracking(Base):
     process_run_end_date_time = Column(DateTime, nullable=True)
     process_run_record_count = Column(Integer, nullable=False, default=0)
     process_run_actor_id = Column(
-        Integer, ForeignKey("process_tracker.actor_lkup.actor_id")
+        Integer, ForeignKey("process_tracker.actor_lkup.actor_id"), nullable=False
     )
     is_latest_run = Column(Boolean, nullable=False, default=False)
 
-    errors = relationship("ErrorTracking", back_populates="error_tracking")
-    extracts = relationship("ExtractProcess", back_populates="extract_processes")
-    process = relationship("Process", back_populates="process_tracking")
+    errors = relationship(
+        "ErrorTracking", back_populates="error_tracking", passive_deletes="all"
+    )
+    extracts = relationship(
+        "ExtractProcess", back_populates="extract_processes", passive_deletes="all"
+    )
+    process = relationship(
+        "Process", back_populates="process_tracking", passive_deletes="all"
+    )
 
     def __repr__(self):
 

--- a/process_tracker/models/source.py
+++ b/process_tracker/models/source.py
@@ -15,6 +15,7 @@ class Source(Base):
         Integer,
         Sequence("source_lkup_source_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     source_name = Column(String(250), nullable=False, unique=True)
 

--- a/process_tracker/models/system.py
+++ b/process_tracker/models/system.py
@@ -15,6 +15,7 @@ class System(Base):
         Integer,
         Sequence("system_lkup_system_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     system_key = Column(String(250), nullable=False, unique=True)
     system_value = Column(String(250), nullable=False)

--- a/process_tracker/models/tool.py
+++ b/process_tracker/models/tool.py
@@ -15,6 +15,7 @@ class Tool(Base):
         Integer,
         Sequence("tool_lkup_tool_id_seq", schema="process_tracker"),
         primary_key=True,
+        nullable=False,
     )
     tool_name = Column(String(250), nullable=False, unique=True)
 


### PR DESCRIPTION
:bug: When deleting records foreign keys had chance of going null

Wanted to guarantee as much as possible that foreign key relationships
remain enforced.

Closes #33