### PR TITLE
process_tracker_python-57 Encryptable data store passwords

### DIFF
--- a/process_tracker/cli.py
+++ b/process_tracker/cli.py
@@ -6,6 +6,7 @@ import logging
 
 from process_tracker.utilities.data_store import DataStore
 from process_tracker.utilities.logging import console
+from process_tracker.utilities.utilities import encrypt_password
 
 data_store = DataStore()
 logger = logging.getLogger("Process Tracker")
@@ -211,4 +212,15 @@ def update(
         max_memory=max_memory,
         processing_unit=processing_unit,
         memory_unit=memory_unit,
+    )
+
+
+@main.command()
+@click.option("-p", "--password", help="The password to be encrypted")
+def encrypt(password):
+    click.echo("Attempting to encrypt the provided password.")
+    password = encrypt_password(password=password)
+    click.echo("Encrypted password is now: %s" % password)
+    click.echo(
+        "When storing in your config file, please be sure to include 'Encrypted ' as well as the hash."
     )

--- a/process_tracker/utilities/data_store.py
+++ b/process_tracker/utilities/data_store.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import database_exists
 
 from process_tracker.utilities.settings import SettingsManager
+from process_tracker.utilities.utilities import decrypt_password
 
 from process_tracker.models.model_base import Base
 from process_tracker.models.actor import Actor
@@ -637,6 +638,9 @@ class DataStore:
             )
 
             raise Exception(errors)
+
+        if "Encrypted" in data_store_password:
+            data_store_password = decrypt_password(password=data_store_password)
 
         if data_store_type in supported_data_stores:
 

--- a/process_tracker/utilities/utilities.py
+++ b/process_tracker/utilities/utilities.py
@@ -1,9 +1,12 @@
 """
 Space for generalized helpers that can be utilized across the entire framework.
 """
+import base64
 import logging
 
 from process_tracker.utilities.settings import SettingsManager
+
+key = "ZE77KfeJ1P9gHfgVzsZIaafzoZXEuwKI7wDe4c1F8AY="
 
 log_level = SettingsManager().determine_log_level()
 
@@ -56,3 +59,43 @@ def timestamp_converter(data_store_type, timestamp):
         timestamp = timestamp
 
     return timestamp
+
+
+def encrypt_password(password):
+    """
+    Helper function for encrypting passwords (specifically for data store connections).
+    :param password:
+    :return:
+    """
+    encoded_chars = []
+
+    for i in range(len(password)):
+        key_c = key[i % len(key)]
+        encoded_c = chr(ord(password[i]) + ord(key_c) % 256)
+        encoded_chars.append(encoded_c)
+
+    encoded_password = "".join(encoded_chars).encode()
+    encrypted_password = base64.urlsafe_b64encode(encoded_password).decode()
+
+    return "Encrypted %s" % encrypted_password
+
+
+def decrypt_password(password):
+    """
+    Helper function for decrypting passwords (specifically for data store connections).
+    :param password:
+    :return:
+    """
+
+    password = password.replace("Encrypted ", "")
+
+    decode = []
+    encode = base64.urlsafe_b64decode(password).decode()
+    for i in range(len(encode)):
+        key_c = key[i % len(key)]
+        dec_c = chr((256 + ord(encode[i]) - ord(key_c)) % 256)
+        decode.append(dec_c)
+
+    decrypted_password = "".join(decode)
+
+    return decrypted_password

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -927,4 +927,14 @@ class TestCli(unittest.TestCase):
         self.assertEqual("Updated", given_name)
         self.assertEqual(0, result.exit_code)
 
-    # def test_update_process_dependency(self):
+    def test_encrypt_password(self):
+        """
+        Testing that when trying to encrypt a password via CLI, it is encrypted.
+        :return:
+        """
+
+        result = self.runner.invoke(main, "encrypt -p MySecretPassword")
+
+        expected_result = "Encrypted wqfCvsKKwpzCrsOYw4rCvsKBwrHCrMOawr_DlcOZwro="
+
+        self.assertIn(expected_result, result.output)

--- a/tests/utilities/test_utilities.py
+++ b/tests/utilities/test_utilities.py
@@ -46,3 +46,25 @@ class TestUtilities(unittest.TestCase):
         )
 
         self.assertEqual(expected_result, given_result)
+
+    def test_encrypt_password(self):
+        """
+        Given a password, it's hash will be returned.
+        :return:
+        """
+        expected_result = "Encrypted wqfCvsKKwpzCrsOYw4rCvsKBwrHCrMOawr_DlcOZwro="
+        given_result = utilities.encrypt_password("MySecretPassword")
+
+        self.assertEqual(expected_result, given_result)
+
+    def test_decrypt_password(self):
+        """
+        Given an encrypted password, return it's plaintext.
+        :return:
+        """
+        expected_result = "MySecretPassword"
+        given_result = utilities.decrypt_password(
+            password="Encrypted wqfCvsKKwpzCrsOYw4rCvsKBwrHCrMOawr_DlcOZwro="
+        )
+
+        self.assertEqual(expected_result, given_result)


### PR DESCRIPTION
:sparkles: Data store passwords are now encrypted

Added ability to encrypt passwords so they aren't just stored in plain
text in config files.  This is not cryptographically secure, nor is it
intended to be.  Just wanted to have the option to not store passwords
in just plain text.

Closes #57