### PR TITLE
process_tracker_python-12 Handling Process Dependency failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ pip-selfcheck.json
 .idea/misc.xml
 .idea/modules.xml
 .idea/process_tracker_python.iml
+/tests/s3:/
+/tests/s3:\/

--- a/configs/mysql_config.ini
+++ b/configs/mysql_config.ini
@@ -1,5 +1,6 @@
 [DEFAULT]
 log_level = ERROR
+max_sequential_failures = 5
 data_store_type = mysql
 data_store_username = pt_admin
 data_store_password = Testing1!

--- a/configs/postgres_config.ini
+++ b/configs/postgres_config.ini
@@ -1,5 +1,6 @@
 [DEFAULT]
 log_level = ERROR
+max_sequential_failures = 5
 data_store_type = postgresql
 data_store_username = pt_admin
 data_store_password = Testing1!

--- a/dbscripts/mysql_process_tracker_defaults.sql
+++ b/dbscripts/mysql_process_tracker_defaults.sql
@@ -11,6 +11,7 @@ INSERT INTO process_tracker.extract_status_lkup (extract_status_id, extract_stat
 INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'running');
 INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'completed');
 INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'failed');
+INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'on hold');
 
 INSERT INTO process_tracker.error_type_lkup (error_type_id, error_type_name) VALUES (default, 'File Error');
 INSERT INTO process_tracker.error_type_lkup (error_type_id, error_type_name) VALUES (default, 'Data Error');

--- a/dbscripts/postgresql_process_tracker_defaults.sql
+++ b/dbscripts/postgresql_process_tracker_defaults.sql
@@ -11,6 +11,8 @@ INSERT INTO process_tracker.extract_status_lkup (extract_status_id, extract_stat
 INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'running');
 INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'completed');
 INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'failed');
+INSERT INTO process_tracker.process_status_lkup (process_status_id, process_status_name) VALUES (default, 'on hold');
+
 
 INSERT INTO process_tracker.error_type_lkup (error_type_id, error_type_name) VALUES (default, 'File Error');
 INSERT INTO process_tracker.error_type_lkup (error_type_id, error_type_name) VALUES (default, 'Data Error');

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -746,7 +746,7 @@ class TestProcessTracker(unittest.TestCase):
             )
 
         self.assertTrue(
-            "The process %s is currently running or on hold." % process_name
+            "The process On Hold Previous Run Test is currently running or on hold."
             in str(context.exception)
         )
 

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -971,8 +971,8 @@ class TestProcessTracker(unittest.TestCase):
             self.process_tracker.register_new_process_run()
 
         return self.assertTrue(
-            "The process Testing Process Tracking Initialization "
-            "is currently running." in str(context.exception)
+            "The process Testing Process Tracking Initialization is currently running or on hold."
+            in str(context.exception)
         )
 
     def test_register_new_process_run_with_previous_run(self):

--- a/tests/utilities/test_utilities.py
+++ b/tests/utilities/test_utilities.py
@@ -26,7 +26,7 @@ class TestUtilities(unittest.TestCase):
             utilities.determine_low_high_date(
                 date=lower_low_date, previous_date=low_date, date_type="blarg"
             )
-        print(context.exception)
+
         return self.assertTrue(
             "blarg is not a valid date_type." in str(context.exception)
         )


### PR DESCRIPTION
:sparkles: Processes can now be put 'on hold' if too many failures

If a process hits too many failures (up to the new setting, max_concurrent_failures)
then the run will be set to 'on hold'.  It will remain on hold until someone
manually changes the status.

Closes #12