### PR TITLE
process_tracker_python-130 Add flag for is_partition in source_object…

### DIFF
--- a/dbscripts/mysql_process_tracker.sql
+++ b/dbscripts/mysql_process_tracker.sql
@@ -532,6 +532,7 @@ create table source_object_attribute_lkup
 	default_value_number decimal null,
 	is_key boolean default FALSE not null,
 	is_filter boolean default FALSE not null,
+	is_partition boolean default FALSE not null,
 	constraint source_object_attribute_lkup_udx01
 		unique (source_object_id, source_object_attribute_name),
 	constraint source_object_attribute_lkup_fk01

--- a/dbscripts/postgresql_process_tracker.sql
+++ b/dbscripts/postgresql_process_tracker.sql
@@ -781,7 +781,8 @@ create table process_tracker.source_object_attribute_lkup
 	default_value_string varchar(250),
 	default_value_number numeric,
 	is_key boolean default false not null,
-	is_filter boolean default false not null
+	is_filter boolean default false not null,
+	is_partition boolean default false not null
 );
 
 alter table process_tracker.source_object_attribute_lkup owner to pt_admin;

--- a/process_tracker/models/source.py
+++ b/process_tracker/models/source.py
@@ -318,6 +318,7 @@ class SourceObjectAttribute(Base):
     default_value_number = Column(Numeric, nullable=True)
     is_key = Column(Boolean, nullable=False, default=False)
     is_filter = Column(Boolean, nullable=False, default=False)
+    is_partition = Column(Boolean, nullable=False, default=False)
 
     UniqueConstraint(source_object_id, source_object_attribute_name)
 

--- a/process_tracker/process_tracker.py
+++ b/process_tracker/process_tracker.py
@@ -704,6 +704,7 @@ class ProcessTracker:
                 SourceObjectAttribute.source_object_attribute_name,
                 SourceObjectAttribute.is_key,
                 SourceObjectAttribute.is_filter,
+                SourceObjectAttribute.is_partition,
             )
             .join(SourceObject, SourceObjectAttribute.source_objects)
             .join(Source, SourceObject.sources)
@@ -724,6 +725,7 @@ class ProcessTracker:
                     "source_object_attribute_name": attribute.source_object_attribute_name,
                     "is_key": attribute.is_key,
                     "is_filter": attribute.is_filter,
+                    "is_partition": attribute.is_partition,
                 }
             )
 
@@ -745,6 +747,7 @@ class ProcessTracker:
                 SourceObjectAttribute.source_object_attribute_name,
                 SourceObjectAttribute.is_key,
                 SourceObjectAttribute.is_filter,
+                SourceObjectAttribute.is_partition,
             )
             .join(SourceObject, SourceObjectAttribute.source_objects)
             .join(Source, SourceObject.sources)
@@ -765,6 +768,7 @@ class ProcessTracker:
                     "target_object_attribute_name": attribute.source_object_attribute_name,
                     "is_key": attribute.is_key,
                     "is_filter": attribute.is_filter,
+                    "is_partition": attribute.is_partition,
                 }
             )
 

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -2060,6 +2060,7 @@ class TestProcessTracker(unittest.TestCase):
                 "source_object_attribute_name": "attr_1",
                 "is_key": False,
                 "is_filter": False,
+                "is_partition": False,
             },
             {
                 "source_name": "source",
@@ -2067,6 +2068,7 @@ class TestProcessTracker(unittest.TestCase):
                 "source_object_attribute_name": "attr_2",
                 "is_key": False,
                 "is_filter": False,
+                "is_partition": False,
             },
         ]
 
@@ -2093,6 +2095,7 @@ class TestProcessTracker(unittest.TestCase):
                 "target_object_attribute_name": "attr_1",
                 "is_key": False,
                 "is_filter": False,
+                "is_partition": False,
             },
             {
                 "target_name": "target",
@@ -2100,6 +2103,7 @@ class TestProcessTracker(unittest.TestCase):
                 "target_object_attribute_name": "attr_2",
                 "is_key": False,
                 "is_filter": False,
+                "is_partition": False,
             },
         ]
 


### PR DESCRIPTION
…_attribute

:sparkles:  Added field for source object attributes to be flagged as
partition fields

Requirement was specifically for files/data stores that allow for
partitioning.  When flag is set, those are the field(s) that the data
should be partitioned on.  This is separate from is_key.

Closes: #130