### PR TITLE
process_tracker_python-137 Add Instance name to Process Tracker table

### DIFF
--- a/dbscripts/mysql_process_tracker.sql
+++ b/dbscripts/mysql_process_tracker.sql
@@ -337,6 +337,9 @@ create table process_tracking
 	process_run_record_count int not null,
 	process_run_actor_id int null,
 	is_latest_run tinyint(1) not null,
+	process_run_name varchar(250) null,
+	constraint process_tracking_process_run_name_uindex
+		unique (process_run_name),
 	constraint process_tracking_ibfk_1
 		foreign key (process_id) references process (process_id),
 	constraint process_tracking_ibfk_2
@@ -344,6 +347,8 @@ create table process_tracking
 	constraint process_tracking_ibfk_3
 		foreign key (process_run_actor_id) references actor_lkup (actor_id)
 );
+
+
 
 create table error_tracking
 (

--- a/dbscripts/postgresql_process_tracker.sql
+++ b/dbscripts/postgresql_process_tracker.sql
@@ -364,7 +364,8 @@ create table process_tracking
 	process_run_actor_id integer
 		constraint process_tracking_fk03
 			references actor_lkup,
-	is_latest_run boolean default false
+	is_latest_run boolean default false,
+	process_run_name varchar(250) null
 );
 
 comment on table process_tracking is 'Tracking table of process runs.';
@@ -399,6 +400,9 @@ create index process_tracking_idx02
 
 create index process_tracking_idx03
 	on process_tracking (process_run_low_date_time, process_run_high_date_time);
+
+create unique index process_tracking_udx01
+	on process_tracking (process_run_name);
 
 create table cluster_process
 (

--- a/process_tracker/models/process.py
+++ b/process_tracker/models/process.py
@@ -512,6 +512,7 @@ class ProcessTracking(Base):
         Integer, ForeignKey("process_tracker.actor_lkup.actor_id"), nullable=False
     )
     is_latest_run = Column(Boolean, nullable=False, default=False)
+    process_run_name = Column(String(250), unique=True, nullable=True)
 
     actor = relationship("Actor")
     errors = relationship(

--- a/process_tracker/process_tracker.py
+++ b/process_tracker/process_tracker.py
@@ -60,6 +60,7 @@ class ProcessTracker:
     def __init__(
         self,
         process_name=None,
+        process_run_name=None,
         process_type=None,
         actor_name=None,
         tool_name=None,
@@ -77,6 +78,7 @@ class ProcessTracker:
         """
         ProcessTracker is the primary engine for tracking data integration processes.
         :param process_name: Name of the process being tracked.
+        :param process_run_name: Optional name of the process run.
         :param actor_name: Name of the person or environment runnning the process.
         :param tool_name: Name of the tool used to run the process.
         :param sources: A single source name or list of source names for the given process. If source_objects is set,
@@ -148,6 +150,7 @@ class ProcessTracker:
 
                 self.process_name = process_run.process.process_name
                 self.process_tracking_run = process_run
+                self.process_run_name = process_run.process_run_name
 
             else:
                 error_msg = "Process run not found based on id %s." % process_run_id
@@ -231,6 +234,7 @@ class ProcessTracker:
                 self.targets = None
 
             self.process_name = process_name
+            self.process_run_name = process_run_name
 
             self.process_tracking_run = self.register_new_process_run()
 
@@ -976,6 +980,7 @@ class ProcessTracker:
                 process_run_start_date_time=datetime.now(),
                 process_run_actor_id=self.actor.actor_id,
                 is_latest_run=True,
+                process_run_name=self.process_run_name,
             )
 
             self.session.add(new_run)

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -99,6 +99,7 @@ class TestProcessTracker(unittest.TestCase):
         """
         self.process_tracker = ProcessTracker(
             process_name="Testing Process Tracking Initialization",
+            process_run_name="Testing Process Tracking Initialization 01",
             process_type="Extract",
             actor_name="UnitTesting",
             tool_name="Spark",
@@ -1054,6 +1055,9 @@ class TestProcessTracker(unittest.TestCase):
         """
 
         self.process_tracker.change_run_status(new_status="completed")
+        self.process_tracker.process_run_name = (
+            "Testing Process Tracking Initialization 02"
+        )
         self.process_tracker.register_new_process_run()
 
         process_runs = (
@@ -1087,6 +1091,9 @@ class TestProcessTracker(unittest.TestCase):
             child_process_id=self.process_id,
         )
 
+        self.process_tracker.process_run_name = (
+            "Testing Process Tracking Initialization 02"
+        )
         self.process_tracker.register_new_process_run()
 
         given_count = (
@@ -2166,6 +2173,9 @@ class TestProcessTracker(unittest.TestCase):
             new_process_tracker.schedule_frequency.schedule_frequency_name
         )
 
+        expected_process_run_name = self.process_tracker.process_run_name
+        given_process_run_name = new_process_tracker.process_run_name
+
         self.assertEqual(expected_process_name_result, given_process_name_result)
         self.assertEqual(expected_actor_result, given_actor_result)
         self.assertEqual(expected_process_type_result, given_process_type_result)
@@ -2173,6 +2183,7 @@ class TestProcessTracker(unittest.TestCase):
         self.assertEqual(
             expected_schedule_frequency_result, given_schedule_frequency_result
         )
+        self.assertEqual(expected_process_run_name, given_process_run_name)
 
     def test_determine_process_sources(self):
         """


### PR DESCRIPTION
:sparkles:  Process instances can now have optional unique names

Closes #137