### PR TITLE
process_tracker_python-157 Config file being reset on import

### DIFF
--- a/process_tracker/utilities/settings.py
+++ b/process_tracker/utilities/settings.py
@@ -40,10 +40,7 @@ class SettingsManager:
         else:
             self.config_path = config_location
 
-            if (
-                "process_tracker_config.ini" not in self.config_path
-                and ".ini" not in self.config_path
-            ):
+            if ".ini" not in self.config_path:
                 self.logger.debug(
                     "process_tracker_config.ini not present.  Appending to %s"
                     % self.config_path
@@ -59,7 +56,7 @@ class SettingsManager:
                 self.logger.debug("Config file is now %s" % self.config_file)
             else:
                 self.logger.debug(
-                    "process_tracker_config.ini present.  Setting config_path to config_file."
+                    "process_tracker config file present in path.  Setting config_path to config_file."
                 )
                 self.config_file = self.config_path
 


### PR DESCRIPTION
:bug: Issue with logic when config_location provided

Logical fault caused the config file in config_location to be overwritten as if it
didn't exist.