### PR TITLE
process_tracker_python-161 Modify schedule helper to return process o…

### DIFF
--- a/process_tracker/process_tracker.py
+++ b/process_tracker/process_tracker.py
@@ -641,13 +641,13 @@ class ProcessTracker:
         process_list = list()
 
         processes = (
-            self.data_store.session.query(Process.process_id)
+            self.data_store.session.query(Process)
             .join(ScheduleFrequency)
             .filter(ScheduleFrequency.schedule_frequency_name == frequency)
         )
 
         for process in processes:
-            process_list.append(process.process_id)
+            process_list.append(process)
 
         return process_list
 

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -2008,7 +2008,7 @@ class TestProcessTracker(unittest.TestCase):
 
         given_result = process.find_process_by_schedule_frequency(frequency="hourly")
 
-        expected_result = [process.process.process_id]
+        expected_result = [process.process]
 
         self.assertEqual(expected_result, given_result)
 


### PR DESCRIPTION
…bjects and not ids

:sparkles: Modified schedule finder to return process objects and not just the ids

Closes #161