### PR TITLE
process_tracker_python-159 Increase filetype code size

### DIFF
--- a/dbscripts/mysql_process_tracker.sql
+++ b/dbscripts/mysql_process_tracker.sql
@@ -74,7 +74,7 @@ create table extract_filetype_lkup
 (
 	extract_filetype_id int auto_increment
 		primary key,
-	extract_filetype_code varchar(5) not null,
+	extract_filetype_code varchar(25) not null,
 	extract_filetype varchar(75) not null,
 	delimiter_char char null,
 	quote_char char null,

--- a/dbscripts/postgresql_process_tracker.sql
+++ b/dbscripts/postgresql_process_tracker.sql
@@ -251,7 +251,7 @@ create table extract_filetype_lkup
 	extract_filetype_id serial not null
 		constraint extract_filetype_lkup_pk
 			primary key,
-	extract_filetype_code varchar(5) not null,
+	extract_filetype_code varchar(25) not null,
 	extract_filetype varchar(75) not null,
 	delimiter_char char,
 	quote_char char,

--- a/process_tracker/models/extract.py
+++ b/process_tracker/models/extract.py
@@ -74,7 +74,7 @@ class ExtractFileType(Base):
         primary_key=True,
         nullable=False,
     )
-    extract_filetype_code = Column(String(5), nullable=False)
+    extract_filetype_code = Column(String(25), nullable=False)
     extract_filetype = Column(String(75), nullable=False, unique=True)
     delimiter_char = Column(String(1), nullable=True)
     quote_char = Column(String(1), nullable=True)


### PR DESCRIPTION
:sparkles: Increased filetype code size to 25

Hit issue where some file type codes were longer than expected.  Modified field to support them.

Closes #159