### PR TITLE
process_tracker_python-160 Is process type required for Process Tracker?

### DIFF
--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -2218,7 +2218,7 @@ class TestProcessTracker(unittest.TestCase):
     def test_ensure_nulls_caught_on_instantiation(self):
         """
         With the adding of the ability of have a process_tracking_id we have to allow for nulled values for process_name
-        and process_type.  If ProcessTracker is instantiated with either (or both) being null, an exception should be
+        .  If ProcessTracker is instantiated with process_name being null, an exception should be
         raised.
         :return:
         """
@@ -2227,6 +2227,20 @@ class TestProcessTracker(unittest.TestCase):
 
             ProcessTracker()
 
-        return self.assertTrue(
-            "process_name and process_type must be set." in str(context.exception)
+        return self.assertTrue("process_name must be set." in str(context.exception))
+
+    def test_ensure_process_type_returned_with_given_process_name(self):
+        """Ensuring that if just the process name is passed, the process type will be retrieved for that given process"""
+
+        self.process_tracker.change_run_status("completed")
+
+        test_process = ProcessTracker(
+            process_name="Testing Process Tracking Initialization",
+            actor_name="UnitTesting",
+            tool_name="Spark",
         )
+
+        given_result = test_process.process_type.process_type_name
+        expected_result = "Extract"
+
+        return self.assertEqual(expected_result, given_result)


### PR DESCRIPTION
:sparkles: process_type now optional if process already exists

If process has already been added ahead of time (i.e. thru the web frontend that is to be built), then process_type is not required.
If process is being added from code, then process_type MUST still be included.

Closes #160